### PR TITLE
Fix EnumConverter for nullable enums

### DIFF
--- a/Slapper.AutoMapper/Slapper.AutoMapper.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.cs
@@ -460,7 +460,8 @@ namespace Slapper
                 /// <returns>Boolean response.</returns>
                 public bool CanConvert( object value, Type type )
                 {
-                    return type.IsEnum;
+                    var conversionType = Nullable.GetUnderlyingType(type) ?? type;
+                    return conversionType.IsEnum;
                 }
 
                 /// <summary>


### PR DESCRIPTION
Conversion failed because nullable enums return false for `type.IsEnum`