### PR TITLE
Fixes issue #48 w/ tests  + fixes perf test

### DIFF
--- a/Slapper.AutoMapper.Tests/CachingBehaviorTests.cs
+++ b/Slapper.AutoMapper.Tests/CachingBehaviorTests.cs
@@ -119,8 +119,10 @@ namespace Slapper.Tests
         }
 
         [Test]
-        public void Test_Long_Ids_With_Colliding_Hasvalues()
+        public void Test_Long_Ids_With_Colliding_HashValues()
         {
+            // This test could fail if MS GetHashCode implementation for long changed. We would then have to find new long values
+            // having the same hashcode.
             const long longId1 = 95988224123597;
             var item1 = new Dictionary<string, object>()
                                                {

--- a/Slapper.AutoMapper.Tests/CachingBehaviorTests.cs
+++ b/Slapper.AutoMapper.Tests/CachingBehaviorTests.cs
@@ -47,6 +47,13 @@ namespace Slapper.Tests
             public int Id { get; set; }
         }
 
+
+        public class OrderWithLongId
+        {
+            public long Id { get; set; }
+            public List<OrderItem> OrderItems { get; set; }
+        }
+
         [Test]
         public void Previously_Instantiated_Objects_Will_Be_Returned_Until_The_Cache_Is_Cleared()
         {
@@ -109,6 +116,30 @@ namespace Slapper.Tests
             var employeeList = AutoMapper.Map<Employee>(list).ToList();
 
             Assert.AreSame(employeeList[0].Department, employeeList[1].Department);           
+        }
+
+        [Test]
+        public void Test_Long_Ids_With_Colliding_Hasvalues()
+        {
+            const long longId1 = 95988224123597;
+            var item1 = new Dictionary<string, object>()
+                                               {
+                                                   { "Id", longId1 },
+                                                   { "OrderDetail_Id", 1 }
+                                               };
+
+            const long longId2 = 95983929156300;
+            var item2 = new Dictionary<string, object>()
+                                               {
+                                                   { "Id", longId2 },
+                                                   { "OrderDetail_Id", 2 }
+                                               };
+
+            var list = new List<Dictionary<string, object>>() { item1, item2 };
+            var orderList = AutoMapper.Map<OrderWithLongId>(list).ToList();
+
+            Assert.AreEqual(longId1.GetHashCode(), longId2.GetHashCode());
+            Assert.AreEqual(orderList.Count, list.Count);
         }
 
         [Test]

--- a/Slapper.AutoMapper.Tests/ComplexMapTests.cs
+++ b/Slapper.AutoMapper.Tests/ComplexMapTests.cs
@@ -117,11 +117,16 @@ namespace Slapper.Tests
         }
 
         /// <summary>
+        /// OLD SUMMARY ===
         /// When mapping, it internally keeps a cache of instantiated objects with the key being the
         /// hash of the objects identifier hashes summed together so when another record with the exact
         /// same identifier hash is detected, it will re-use the existing instantiated object instead of
         /// creating a second one alleviating the burden of the consumer of the library to group objects
         /// by their identifier.
+        /// ===
+        /// This was flawed as SAME HASHCODE DOESN'T MEAN SAME VALUE. Hash collisions would lead to
+        /// wrongly reusing an instance instead of creating a new one (issue #48).
+        /// It's now fixed as real identifier values are compared, not their hashes anymore.
         /// </summary>
         [Test]
         public void Can_Detect_Duplicate_Parent_Members_And_Properly_Instantiate_The_Object_Only_Once()

--- a/Slapper.AutoMapper.Tests/PerformanceTests.cs
+++ b/Slapper.AutoMapper.Tests/PerformanceTests.cs
@@ -105,9 +105,9 @@ namespace Slapper.Tests
                     { "CustomerId", i },
                     { "FirstName", "Bob" },
                     { "LastName", "Smith" },
-                    { "Orders_Id", i },
+                    { "Orders_OrderId", i },
                     { "Orders_OrderTotal", 50.50m },
-                    { "Orders_OrderDetails_Id", i },
+                    { "Orders_OrderDetails_OrderDetailId", i },
                     { "Orders_OrderDetails_OrderDetailTotal", 50.50m },
                     { "Orders_OrderDetails_Product_Id", 546 },
                     { "Orders_OrderDetails_Product_ProductName", "Black Bookshelf" }

--- a/Slapper.AutoMapper/Slapper.AutoMapper.Cache.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.Cache.cs
@@ -43,7 +43,7 @@ namespace Slapper
         /// <summary>
         /// Contains the methods and members responsible for this libraries caching concerns.
         /// </summary>
-        public static class Cache
+        internal static class Cache
         {
             /// <summary>
             /// The name of the instance cache stored in the logical call context.
@@ -115,13 +115,13 @@ namespace Slapper
             /// unique cache.
             /// </remarks>
             /// <returns>Instance Cache</returns>
-            public static Dictionary<Tuple<int, int, object>, object> GetInstanceCache()
+            public static Dictionary<InternalHelpers.InstanceKey,object> GetInstanceCache()
             {
-                var instanceCache = InternalHelpers.ContextStorage.Get<Dictionary<Tuple<int, int, object>, object>>(InstanceCacheContextStorageKey);
+                var instanceCache = InternalHelpers.ContextStorage.Get<Dictionary<InternalHelpers.InstanceKey, object>>(InstanceCacheContextStorageKey);
 
                 if (instanceCache == null)
                 {
-                    instanceCache = new Dictionary<Tuple<int, int, object>, object>();
+                    instanceCache = new Dictionary<InternalHelpers.InstanceKey, object>();
 
                     InternalHelpers.ContextStorage.Store(InstanceCacheContextStorageKey, instanceCache);
                 }

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -72,7 +72,7 @@ namespace Slapper
             {
                 public bool Equals(InstanceKey other) {
                     return Equals(Type, other.Type) 
-                        && ReferenceEquals(ParentInstance, other.ParentInstance) 
+                        && Equals(ParentInstance, other.ParentInstance) 
                         && StructuralComparisons.StructuralEqualityComparer.Equals(IdentifierValues, other.IdentifierValues);
                 }
 

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -396,6 +396,26 @@ namespace Slapper
             }
 
             /// <summary>
+            /// Computes a key for storing and identifying an instance in the cache.
+            /// </summary>
+            /// <param name="type">Type of instance to get</param>
+            /// <param name="properties">List of properties and values</param>
+            /// <param name="parentInstance">Parent instance. Can be NULL if this is the root instance.</param>
+            /// <returns>
+            /// InstanceKey that will be unique for given set of identifiers values for the type. If the type isn't associated with any 
+            /// identifier, the return value is made unique by generating a Guid.
+            /// </returns>
+            private static InstanceKey GetCacheKey(Type type, IDictionary<string, object> properties, object parentInstance)
+            {
+                var identifierValues = GetIdentifiers(type)?.Select(id => properties[id]).DefaultIfEmpty(Guid.NewGuid()).ToArray()
+                    ?? new object[] { Guid.NewGuid() };
+
+                var key = new InstanceKey(type, identifierValues, parentInstance);
+                return key;
+            }
+
+
+            /// <summary>
             /// Gets a new or existing instance depending on whether an instance with the same identifiers already existing
             /// in the instance cache.
             /// </summary>
@@ -423,15 +443,6 @@ namespace Slapper
                 }
 
                 return Tuple.Create(isNewlyCreatedInstance, instance, key);
-            }
-
-            private static InstanceKey GetCacheKey(Type type, IDictionary<string, object> properties, object parentInstance)
-            {
-                var identifierValues = GetIdentifiers(type)?.Select(id => properties[id]).DefaultIfEmpty(Guid.NewGuid()).ToArray()
-                    ?? new object[] {Guid.NewGuid()};
-
-                var key = new InstanceKey(type, identifierValues, parentInstance);
-                return key;
             }
 
             /// <summary>

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -49,6 +49,12 @@ namespace Slapper
         /// </summary>
         internal static class InternalHelpers
         {
+            /// <summary>
+            /// Combine several hashcodes into a single new one. This implementation was grabbed from http://stackoverflow.com/a/34229665 where it is introduced 
+            /// as MS implementation of GetHashCode() for strings.
+            /// </summary>
+            /// <param name="hashCodes">Hascodes to be combined.</param>
+            /// <returns>A new Hascode value combining those passed as parameters.</returns>
             private static int CombineHashCodes(params int[] hashCodes)
             {
                 int hash1 = (5381 << 16) + 5381;

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -414,6 +414,8 @@ namespace Slapper
             /// <returns>
             /// InstanceKey that will be unique for given set of identifiers values for the type. If the type isn't associated with any 
             /// identifier, the return value is made unique by generating a Guid.
+            /// ASSUMES GetIdentifiers(type) ALWAYS RETURN IDENTIFIERS IN THE SAME ORDER FOR A GIVEN TYPE.
+            /// This is certainly the case as long as GetIdentifiers caches its result for a given type (which it does by 2016-11-25).
             /// </returns>
             private static InstanceKey GetCacheKey(Type type, IDictionary<string, object> properties, object parentInstance)
             {

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -427,9 +427,10 @@ namespace Slapper
 
             private static InstanceKey GetCacheKey(Type type, IDictionary<string, object> properties, object parentInstance)
             {
-                var identifiers= GetIdentifiers(type).Select(id => properties[id]).ToArray();
+                var identifierValues = GetIdentifiers(type)?.Select(id => properties[id]).DefaultIfEmpty(Guid.NewGuid()).ToArray()
+                    ?? new object[] {Guid.NewGuid()};
 
-                var key = new InstanceKey(type, identifiers, parentInstance);
+                var key = new InstanceKey(type, identifierValues, parentInstance);
                 return key;
             }
 

--- a/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.InternalHelpers.cs
@@ -74,6 +74,10 @@ namespace Slapper
                 return hash1 + (hash2 * 1566083941);
             }
 
+            /// <summary>
+            /// Defines the key for caching instances. Overrides Equality as to get unicity for a given set of identifiers values
+            /// for a given type.
+            /// </summary>
             public struct InstanceKey : IEquatable<InstanceKey>
             {
                 public bool Equals(InstanceKey other) {


### PR DESCRIPTION
Fixes a bug (see issue #48) where distinct identifiers having same hashcodes lead to wrongly merging distinct instances as one during mapping.

The hashcode was used as a key for identity and so identity detection was subject to hash collisions.

In order to fix that behaviour, an `InstanceKey` type was introduced which defines equality as the equality of all the type identifiers and not only their hashcodes.

All tests pass (had to fix complex perf test that had incorrect id names).