### PR TITLE
Change TargetFramework to .NET Standatd 2.0

### DIFF
--- a/Slapper.AutoMapper/Slapper.csproj
+++ b/Slapper.AutoMapper/Slapper.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Slapper.AutoMapper</PackageId>
         <Authors>Randy Burden &amp; contributors</Authors>
@@ -9,7 +9,7 @@
         <PackageLicenseUrl></PackageLicenseUrl>
         <RepositoryUrl>https://github.com/SlapperAutoMapper/Slapper.AutoMapper</RepositoryUrl>
         <Version>2.0.5</Version>
-        <TargetFrameworks>netstandard2.1;net47</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
         <Product>Slapper.AutoMapper.Core</Product>
         <Copyright>Copyright (c) 2016, Randy Burden and contributors. All rights reserved.</Copyright>
         <Description>Slapper.AutoMapper is a mapping library that can convert dynamic data into static types and populate complex nested child objects.</Description>


### PR DESCRIPTION
The change will allow dependencies to be added to libraries targeting .netstandard2.0 which, in turn, can be added to dependencies on both .NET Framework, .NET Core and .NET projects at the same time.